### PR TITLE
Fix authorization errors

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ async function createServer() {
      * Configure the app server for authentication and verification
      */
     const cfg: Config = {
-    appName: 'AdminExtensionSDKExampleApp',
+    appName: 'MeteorAdminSDKExampleApp',
     appSecret: 'testSecret',
     authorizeCallbackUrl: `${URL}/authorize/callback`
     };


### PR DESCRIPTION
The authorization process is broken because of using the old App name from https://github.com/shopware/admin-extension-sdk-example-app

Error:
`App registration for "MeteorAdminSDKExampleApp" failed: The app server provided an invalid proof`